### PR TITLE
Adding postinstall for installs directly from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "@font-face definitions using inline base64 to make your life with Polymer easier",
   "scripts": {
     "prepublish": "gulp build",
+    "postinstall": "gulp build",
     "test": "gulp watch"
   },
   "authors": [


### PR DESCRIPTION
This appears to be how it's generally referenced from other components like ui-input, should prevent current issues with missing build/ files.
